### PR TITLE
Try to fix build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.extensions.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.28", "pyquest ~= 0.0.1"],
+    install_requires=["pytket ~= 1.28", "pyquest ~= 0.0.1", "numpy >= 1.20, < 2.0.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
# Description

The pyQuEST has a dependency to numpy but does't specify upper bounded to relevant version https://github.com/rrmeister/pyQuEST/blob/develop/pyproject.toml#L35 so when we try to install pyquest package https://github.com/ferbetanzo/pytket-quest/actions/runs/9870928436/job/27257725939#step:6:219 dy default build system downloading latest version with numpy which is 2.0.0 based on error message.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
